### PR TITLE
Simplify git_delete_gone_branches

### DIFF
--- a/bash_profile_snippets/git_delete_gone_branches.sh
+++ b/bash_profile_snippets/git_delete_gone_branches.sh
@@ -1,7 +1,7 @@
 git_delete_gone_branches() {
     actually_delete="$1"
     git fetch -p
-    branches=$(git branch -av | grep gone | awk '{ print $1 }')
+    branches=$(git for-each-ref --format '%(refname:strip=2) %(upstream:track)' refs/heads | awk '$2 == "[gone]" {print $1}')
     echo -e "Gone branches:\n$branches"
-    if [[ "$actually_delete" == "--delete" ]] ; then echo "Deleting..." ; echo $branches | xargs -L 1 git branch -D ; else echo "use --delete to remove those branches" ; fi
+    if [[ "$actually_delete" == "--delete" ]] ; then echo "Deleting..." ; git branch -D $branches; else echo "use --delete to remove those branches" ; fi
 }


### PR DESCRIPTION
Found this via https://stackoverflow.com/questions/7726949/remove-tracking-branches-no-longer-on-remote#comment116393299_33548037 and wanted to suggest an improvement.

E.g. the current version would always delete a branch named like `remove_gone_items`

- Use `git for-each-ref` and awk to filter only the actually gone branches
- Remove the use of `xargs` and pass branches directly to `git branch -D`